### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Relations are the users connection with an object. If you wanted to add a like b
 * **Multary Operations**: This is an item that can have a variable rating, for instance a star system 1-5 or a movie rating 1-10.
 
 
-#The Code
+# The Code
 
-##Instantiation
+## Instantiation
 Require Shadow in your script, and initialize it. The only required paramater of Shadow is a String. It represents your application namespace as to avoid object collision within your database.
 
 ```php


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
